### PR TITLE
THaEtClient Fix

### DIFF
--- a/hana_decode/THaEtClient.h
+++ b/hana_decode/THaEtClient.h
@@ -76,8 +76,42 @@ private:
     time_t daqt1;
     double ratesum;
 
-    ClassDef(THaEtClient,0)   // ET client connection for online data
+	/* 
+		ET Data de-chunk-ifying.
+		Taken from Bryan Moffit's Repo:
+		https://github.com/bmoffit/evet
+	 */
+	typedef struct etChunkStat
+	{
+		uint32_t *data;
+		size_t length;
+		int32_t endian;
+		int32_t swap;
 
+		int32_t  evioHandle;
+	} etChunkStat_t;
+	typedef struct evetHandle
+	{
+		et_sys_id etSysId;
+		et_att_id etAttId;
+		et_event **etChunk;      // pointer to array of et_events (pe)
+		int32_t  etChunkSize;    // user requested (et_events in a chunk)
+		int32_t  etChunkNumRead; // actual read from et_events_get
+		int32_t  currentChunkID;  // j
+		etChunkStat_t currentChunkStat; // data, len, endian, swap
+		int32_t verbose=1; // 0 (none), 1 (data rate), 2+ (verbose)
+
+	} evetHandle_t ;
+
+	int32_t evetOpen(et_sys_id etSysId, int32_t chunk, evetHandle_t &evh);
+	int32_t evetClose(evetHandle_t &evh);
+	int32_t evetReadNoCopy(evetHandle_t &evh, const uint32_t **outputBuffer, uint32_t *length);
+	int32_t evetGetEtChunks(evetHandle_t &evh);
+	int32_t evetGetChunk(evetHandle_t &evh);
+
+	evetHandle evh;
+
+  ClassDef(THaEtClient,0)   // ET client connection for online data
 };
 
 }


### PR DESCRIPTION
## Ports [Bryan Moffit's et_consumer example](https://github.com/bmoffit/evet) into the THaEtClient Class. 

### Issue
The current THaEtClient class is non-functional. 
* It does not properly swap the multi-event chunk returned by the ET system for ET versions > 15.
* Buffer size grows rapidly if `#define ET_CHUNK_SIZE` is set to any value other than 1, resulting in `assert(bpi * evbuffer.size() >= (size_t)nbytes)` failing. 
* It returns the entire multi-event chunk to the user instead of individual events. Returning single events is the expected behavior. 

### Fix
Bryan's example utilizes two additional structures:
* `struct etChunkStat`
* `struct evetHandle`

 and five additional supporting member functions:
* `int32_t evetOpen(et_sys_id etSysId, int32_t chunk, evetHandle_t &evh)`
* `int32_t evetClose(evetHandle_t &evh)`
* `int32_t evetReadNoCopy(evetHandle_t &evh, const uint32_t **outputBuffer, uint32_t *length)`
* `int32_t evetGetEtChunks(evetHandle_t &evh)`
* `int32_t evetGetChunk(evetHandle_t &evh)`

all of which were brought into THaEtClient as private members. These members abstract away the core functionality of `THaEtClient::codaRead(...)`. They correctly obtain multi-event chunks from the ET system, return single events to the user (analogous behavior to the THaCodaFile class), and return the multi-event chunk once all events have been used. 

### Testing
This port was tested with [japan-MOLLER](https://github.com/Mrc1104/japan-MOLLER/tree/poddPR), using a simple software-based CODA setup.  **Note**: A Hall A analyzer test setup is not available for a direct testing, but japan-MOLLER and Podd should be identical in their use of THaEtClient as a wrapper to the ET library. 